### PR TITLE
Refactor tests and fix coveralls report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ script:
   - go test -v -race -covermode=atomic -coverprofile=coverage.out
 
 after_success:
-  - goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+  - goveralls -coverprofile=coverage.out -service=travis-ci

--- a/context_test.go
+++ b/context_test.go
@@ -4,10 +4,10 @@
 package context
 
 import (
+	"errors"
+	"github.com/nbio/st"
 	"net/http"
 	"testing"
-
-	"github.com/nbio/st"
 )
 
 type keyType int
@@ -17,15 +17,12 @@ const (
 	key2
 )
 
-func TestContext(t *testing.T) {
+func TestGetSet(t *testing.T) {
 	req, _ := http.NewRequest("GET", "http://localhost:8080/", nil)
-	empty, _ := http.NewRequest("GET", "http://localhost:8080/", nil)
 	crc := getContextReadCloser(req)
 
-	// Get()
 	st.Expect(t, Get(req, key1), nil)
 
-	// Set()
 	Set(req, key1, "1")
 	st.Expect(t, Get(req, key1), "1")
 	st.Expect(t, len(crc.Context()), 1)
@@ -33,8 +30,12 @@ func TestContext(t *testing.T) {
 	Set(req, key2, "2")
 	st.Expect(t, Get(req, key2), "2")
 	st.Expect(t, len(crc.Context()), 2)
+}
 
-	// GetOk()
+func TestGetOk(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://localhost:8080/", nil)
+
+	Set(req, key1, "1")
 	value, ok := GetOk(req, key1)
 	st.Expect(t, value, "1")
 	st.Expect(t, ok, true)
@@ -47,37 +48,69 @@ func TestContext(t *testing.T) {
 	value, ok = GetOk(req, "nil value")
 	st.Expect(t, value, nil)
 	st.Expect(t, ok, true)
+}
 
-	// GetString()
+func TestGetString(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://localhost:8080/", nil)
+
 	Set(req, "int value", 13)
 	Set(req, "string value", "hello")
 	str := GetString(req, "int value")
 	st.Expect(t, str, "")
 	str = GetString(req, "string value")
 	st.Expect(t, str, "hello")
+}
 
-	// GetAll()
+func TestGetError(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://localhost:8080/", nil)
+
+	err := errors.New("failure")
+	Set(req, "error", err)
+	st.Expect(t, GetError(req, "error"), err)
+
+	st.Expect(t, GetError(req, "unknown_error"), nil)
+}
+
+func TestGetAll(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://localhost:8080/", nil)
+	empty, _ := http.NewRequest("GET", "http://localhost:8080/", nil)
+
+	Set(req, key1, "1")
+	Set(req, key2, "2")
+
 	values := GetAll(req)
-	st.Expect(t, len(values), 5)
+	st.Expect(t, len(values), 2)
+	st.Expect(t, values[key1], "1")
+	st.Expect(t, values[key2], "2")
 
-	// GetAll() for empty request
 	values = GetAll(empty)
 	st.Expect(t, len(values), 0)
+}
 
-	// Delete()
+func TestDelete(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://localhost:8080/", nil)
+	crc := getContextReadCloser(req)
+
+	Set(req, key1, "1")
+	Set(req, key2, "2")
 	Delete(req, key1)
 	st.Expect(t, Get(req, key1), nil)
-	st.Expect(t, len(crc.Context()), 4)
+	st.Expect(t, len(crc.Context()), 1)
 
 	Delete(req, key2)
 	st.Expect(t, Get(req, key2), nil)
-	st.Expect(t, len(crc.Context()), 3)
+	st.Expect(t, len(crc.Context()), 0)
+}
 
-	// Clear()
+func TestClear(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://localhost:8080/", nil)
+	crc := getContextReadCloser(req)
+
 	Set(req, key1, true)
-	values = GetAll(req)
+	Set(req, key2, true)
+	values := GetAll(req)
 	Clear(req)
 	st.Expect(t, len(crc.Context()), 0)
-	val, _ := values["int value"].(int)
-	st.Expect(t, val, 13) // Clear shouldn't delete values grabbed before
+	val, _ := values[key1].(bool)
+	st.Expect(t, val, true)
 }


### PR DESCRIPTION
The tests are now spitted in unit tests and a test was added for `GetError`. The coveralls token was also removed from the `.travis.yml` file to allow coverage report to run on PRs and other repos.
